### PR TITLE
Fixes for 6663, 6641, 6649.

### DIFF
--- a/src/app/pages/data/edit-record/edit-record.component.html
+++ b/src/app/pages/data/edit-record/edit-record.component.html
@@ -2,7 +2,7 @@
     <biosys-header></biosys-header>
     <biosys-navbar></biosys-navbar>
     <biosys-breadcrumbs [items]="breadcrumbItems"></biosys-breadcrumbs>
-    <p-growl [value]="messages"></p-growl>
+    <p-growl [value]="messages" [life]="DEFAULT_GROWL_LIFE"></p-growl>
     <div *ngIf="record">
         <div class="row mt-1">
             <div class="col">

--- a/src/app/pages/data/edit-record/edit-record.component.ts
+++ b/src/app/pages/data/edit-record/edit-record.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { APIService, APIError, Project, Dataset, Record } from '../../../shared/index';
 import { Router, ActivatedRoute } from '@angular/router';
-import { DATASET_TYPE_MAP } from '../../../shared/index';
+import { DATASET_TYPE_MAP, DEFAULT_GROWL_LIFE } from '../../../shared/index';
 import { ConfirmationService, SelectItem, Message } from 'primeng/primeng';
 import * as moment from 'moment/moment';
 
@@ -16,6 +16,7 @@ export class EditRecordComponent implements OnInit {
     private static AMBIGOUS_DATE_PATTERN: RegExp = /^(\d{1,2}).(\d{1,2}).(\d{4})$/;
 
     public DATASET_TYPE_MAP: string = DATASET_TYPE_MAP;
+    public DEFAULT_GROWL_LIFE: number = DEFAULT_GROWL_LIFE;
 
     public breadcrumbItems: any = [];
     public messages: Message[] = [];

--- a/src/app/pages/data/manage-data/manage-data.component.html
+++ b/src/app/pages/data/manage-data/manage-data.component.html
@@ -2,7 +2,7 @@
     <biosys-header></biosys-header>
     <biosys-navbar></biosys-navbar>
     <biosys-breadcrumbs [items]="breadcrumbItems"></biosys-breadcrumbs>
-    <p-growl [value]="messages"></p-growl>
+    <p-growl [value]="messages" [life]="DEFAULT_GROWL_LIFE"></p-growl>
     <div class="row mt-1">
         <div class="col-md">
             <h3>Records for {{dataset?.name}}</h3>
@@ -85,8 +85,8 @@
         <div class="col-md">
             <h4>Upload records</h4>
             <p>Select one or more Excel (xlxs) or CSV files to upload records for the {{ dataset.name }} dataset</p>
-            <p-messages [value]="uploadErrorMessages"></p-messages>
-            <p-messages [value]="uploadWarningMessages"></p-messages>
+            <biosys-expandablemessages [value]="uploadErrorMessages" [maxItems]="5"></biosys-expandablemessages>
+            <biosys-expandablemessages [value]="uploadWarningMessages" [maxItems]="5"></biosys-expandablemessages>
             <biosys-fileuploader name="file" [url]="uploadURL" accept=".csv,.xlsx"
                                  (onUpload)="onUpload($event)" (onError)="onUploadError($event)"
                                  (onSelect)="onUploadSelect($event)" (onBeforeSend)="onUploadBeforeSend($event)"

--- a/src/app/pages/management/edit-dataset/edit-dataset.component.html
+++ b/src/app/pages/management/edit-dataset/edit-dataset.component.html
@@ -38,13 +38,6 @@
                     <div class="col-md-4 text-danger">{{dsErrors['type']}}</div>
                 </div>
                 <div class="row mb-2">
-                    <div class="col-md-2"><label class="field-label">Description</label></div>
-                    <div class="col-md-4">
-                        <textarea pInputTextarea [(ngModel)]="ds.comments" rows="7"></textarea>
-                    </div>
-                    <div class="col-md-4 text-danger">{{dsErrors['comments']}}</div>
-                </div>
-                <div class="row mb-2">
                     <div class="col-md-2"><label class="field-label">Data Package *</label></div>
                     <div class="col-md-8" style="height:500px">
                         <biosys-json-editor id="dataPackage" [options]="editorOptions"

--- a/src/app/pages/management/edit-dataset/edit-dataset.component.html
+++ b/src/app/pages/management/edit-dataset/edit-dataset.component.html
@@ -2,7 +2,7 @@
     <biosys-header></biosys-header>
     <biosys-navbar></biosys-navbar>
     <biosys-breadcrumbs [items]="breadcrumbItems"></biosys-breadcrumbs>
-    <p-growl [value]="messages"></p-growl>
+    <p-growl [value]="messages" [life]="DEFAULT_GROWL_LIFE"></p-growl>
     <div class="row mt-1">
         <div class="col-md">
             <div class="ui-fluid">

--- a/src/app/pages/management/edit-dataset/edit-dataset.component.ts
+++ b/src/app/pages/management/edit-dataset/edit-dataset.component.ts
@@ -1,7 +1,8 @@
 import { Component, OnInit, ViewChild, Input } from '@angular/core';
-import { APIService, APIError, Project, Dataset } from '../../../shared/index';
+import { APIService, APIError, Project, Dataset, JsonEditorComponent, JsonEditorOptions, DEFAULT_GROWL_LIFE }
+    from '../../../shared/index';
 import { Router, ActivatedRoute } from '@angular/router';
-import { JsonEditorComponent, JsonEditorOptions } from '../../../shared/index';
+
 import { ConfirmationService, SelectItem, Message } from 'primeng/primeng';
 import { ModelChoice } from '../../../shared/services/api/api.interfaces';
 
@@ -18,6 +19,8 @@ export class EditDatasetComponent implements OnInit {
 
     @ViewChild(JsonEditorComponent)
     public editor: JsonEditorComponent;
+
+    public DEFAULT_GROWL_LIFE: number = DEFAULT_GROWL_LIFE;
 
     public breadcrumbItems: any = [];
     public typeChoices: SelectItem[];

--- a/src/app/pages/management/edit-project/edit-project.component.html
+++ b/src/app/pages/management/edit-project/edit-project.component.html
@@ -2,7 +2,7 @@
     <biosys-header></biosys-header>
     <biosys-navbar></biosys-navbar>
     <biosys-breadcrumbs [items]="breadcrumbItems"></biosys-breadcrumbs>
-    <p-growl [value]="messages"></p-growl>
+    <p-growl [value]="messages" [life]="DEFAULT_GROWL_LIFE"></p-growl>
     <div class="row mt-3">
         <div class="col-md">
             <div class="mb-1">

--- a/src/app/pages/management/edit-project/edit-project.component.ts
+++ b/src/app/pages/management/edit-project/edit-project.component.ts
@@ -31,8 +31,8 @@ export class EditProjectComponent implements OnInit {
 
     public DATASET_TYPE_MAP: string = DATASET_TYPE_MAP;
     public DEFAULT_GROWL_LIFE: number = DEFAULT_GROWL_LIFE;
-    public TEMPLATE_LATLNG_URL: string = environment.server + '/utils/templates/site/lat-long';
-    public TEMPLATE_EASTNORTH_URL: string = environment.server + '/utils/templates/site/easting-northing';
+    public TEMPLATE_LATLNG_URL: string = environment.server + '/main/download/templates/site/lat-long';
+    public TEMPLATE_EASTNORTH_URL: string = environment.server + '/main/download/templates/site/easting-northing';
     public selectedSites: number[] = [];
     public flatSites: any[];
     public siteAttributeKeys: string[] = [];

--- a/src/app/pages/management/edit-project/edit-project.component.ts
+++ b/src/app/pages/management/edit-project/edit-project.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, ViewChild, Input } from '@angular/core';
-import { APIService, APIError, User, Project, Site, Dataset, ModelChoice, FeatureMapComponent, DATASET_TYPE_MAP }
-    from '../../../shared/index';
+import { APIService, APIError, User, Project, Site, Dataset, ModelChoice, FeatureMapComponent, DATASET_TYPE_MAP,
+    DEFAULT_GROWL_LIFE } from '../../../shared/index';
 import { Router, ActivatedRoute } from '@angular/router';
 import { ConfirmationService, Message, SelectItem } from 'primeng/primeng';
 import { environment } from '../../../../environments/environment';
@@ -30,6 +30,7 @@ export class EditProjectComponent implements OnInit {
     public featureMapComponent: FeatureMapComponent;
 
     public DATASET_TYPE_MAP: string = DATASET_TYPE_MAP;
+    public DEFAULT_GROWL_LIFE: number = DEFAULT_GROWL_LIFE;
     public TEMPLATE_LATLNG_URL: string = environment.server + '/utils/templates/site/lat-long';
     public TEMPLATE_EASTNORTH_URL: string = environment.server + '/utils/templates/site/easting-northing';
     public selectedSites: number[] = [];
@@ -150,6 +151,12 @@ export class EditProjectComponent implements OnInit {
                 detail: 'The dataset was deleted'
             });
         }
+
+        // for some reason the growls won't disappear if messages populated during init, so need
+        // to set a timeout to remove
+        setTimeout(() => {
+            this.messages = [];
+        }, DEFAULT_GROWL_LIFE);
     }
 
     public getDatumLabel(value: string): string {

--- a/src/app/pages/management/edit-site/edit-site.component.html
+++ b/src/app/pages/management/edit-site/edit-site.component.html
@@ -2,7 +2,7 @@
     <biosys-header></biosys-header>
     <biosys-navbar></biosys-navbar>
     <biosys-breadcrumbs [items]="breadcrumbItems"></biosys-breadcrumbs>
-    <p-growl [value]="messages"></p-growl>
+    <p-growl [value]="messages" [life]="DEFAULT_GROWL_LIFE"></p-growl>
     <div class="row mt-1">
         <div class="col-md">
             <h3 *ngIf="site.id">Edit Site</h3>

--- a/src/app/pages/management/edit-site/edit-site.component.ts
+++ b/src/app/pages/management/edit-site/edit-site.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, ViewChild } from '@angular/core';
-import { APIService, APIError, Project, Site, FeatureMapComponent } from '../../../shared/index';
+import { APIService, APIError, Project, Site, FeatureMapComponent, DEFAULT_GROWL_LIFE } from '../../../shared/index';
 import { Router, ActivatedRoute } from '@angular/router';
 import { ConfirmationService, Message } from 'primeng/primeng';
 
@@ -15,6 +15,8 @@ export class EditSiteComponent implements OnInit {
 
     @ViewChild(FeatureMapComponent)
     public featureMapComponent: FeatureMapComponent;
+
+    public DEFAULT_GROWL_LIFE: number = DEFAULT_GROWL_LIFE;
 
     public site: Site = <Site>{};
     public siteErrors: any = {};

--- a/src/app/pages/management/list-projects/list-projects.component.html
+++ b/src/app/pages/management/list-projects/list-projects.component.html
@@ -2,7 +2,7 @@
     <biosys-header></biosys-header>
     <biosys-navbar></biosys-navbar>
     <biosys-breadcrumbs [items]="breadcrumbItems"></biosys-breadcrumbs>
-    <p-growl [value]="messages"></p-growl>
+    <p-growl [value]="messages" [life]="DEFAULT_GROWL_LIFE"></p-growl>
     <div class="row mt-1">
         <div class="col-md">
             <h3>Projects</h3>

--- a/src/app/pages/management/list-projects/list-projects.component.ts
+++ b/src/app/pages/management/list-projects/list-projects.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { APIService, APIError, Project, User } from '../../../shared/index';
+import { APIService, APIError, Project, User, DEFAULT_GROWL_LIFE } from '../../../shared/index';
 import { Router } from '@angular/router';
 import { ConfirmationService, Message } from 'primeng/primeng';
 
@@ -11,6 +11,8 @@ import { ConfirmationService, Message } from 'primeng/primeng';
 })
 
 export class ManagementListProjectsComponent implements OnInit {
+    public DEFAULT_GROWL_LIFE: number = DEFAULT_GROWL_LIFE;
+
     public breadcrumbItems: any = [];
     public projects: Project[] = [];
     public messages: Message[] = [];

--- a/src/app/shared/expandablemessages/expandablemessages.component.css
+++ b/src/app/shared/expandablemessages/expandablemessages.component.css
@@ -1,0 +1,17 @@
+.message-list {
+    display: block;
+}
+
+.expander {
+    margin-left: 4px;
+    margin-right: 4px;
+}
+
+.expander hr {
+    color: white;
+}
+
+.expander a {
+    cursor: pointer;
+    text-decoration: underline;
+}

--- a/src/app/shared/expandablemessages/expandablemessages.component.html
+++ b/src/app/shared/expandablemessages/expandablemessages.component.html
@@ -1,0 +1,35 @@
+<div *ngIf="hasMessages()" class="ui-messages ui-widget ui-corner-all" style="display:block"
+     [ngClass]="{'ui-messages-info':(value[0].severity === 'info'),
+                    'ui-messages-warn':(value[0].severity === 'warn'),
+                    'ui-messages-error':(value[0].severity === 'error'),
+                    'ui-messages-success':(value[0].severity === 'success')}">
+    <div *ngIf="expanded" class="expander">
+        <a (click)="expanded = !expanded">
+            <strong>Truncate</strong>
+        </a>
+    </div>
+    <a href="#" class="ui-messages-close" (click)="clear($event)" *ngIf="closable">
+        <i class="fa fa-close"></i>
+    </a>
+    <span class="ui-messages-icon fa fa-fw fa-2x" [ngClass]="icon"></span>
+    <ul class="message-list">
+        <li *ngFor="let msg of value; let i=index">
+            <ng-template [ngIf]="maxItems == 0 || i < maxItems || expanded">
+                <span class="ui-messages-summary">{{msg.summary}}</span>
+                <span class="ui-messages-detail">{{msg.detail}}</span>
+            </ng-template>
+        </li>
+    </ul>
+    <div *ngIf="value.length > maxItems" class="expander">
+        <div *ngIf="!expanded">
+            <strong>&hellip; {{ value.length - maxItems}} more</strong>
+        </div>
+        <hr>
+        <div>
+            <a (click)="expanded = !expanded">
+                <strong *ngIf="!expanded">Show All</strong>
+                <strong *ngIf="expanded">Truncate</strong>
+            </a>
+        </div>
+    </div>
+</div>

--- a/src/app/shared/expandablemessages/expandablemessages.component.spec.ts
+++ b/src/app/shared/expandablemessages/expandablemessages.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ExpandableMessagesComponent } from './expandablemessages.component';
+
+describe('ExpandablemessagesComponent', () => {
+  let component: ExpandableMessagesComponent;
+  let fixture: ComponentFixture<ExpandableMessagesComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ ExpandableMessagesComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ExpandableMessagesComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should be created', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/expandablemessages/expandablemessages.component.ts
+++ b/src/app/shared/expandablemessages/expandablemessages.component.ts
@@ -1,0 +1,14 @@
+import { Component, Input } from '@angular/core';
+import { Messages } from 'primeng/primeng';
+
+@Component({
+  selector: 'biosys-expandablemessages',
+  templateUrl: './expandablemessages.component.html',
+  styleUrls: ['./expandablemessages.component.css']
+})
+export class ExpandableMessagesComponent extends Messages {
+    @Input()
+    public maxItems: number = 0;
+
+    public expanded: boolean = false;
+}

--- a/src/app/shared/expandablemessages/index.ts
+++ b/src/app/shared/expandablemessages/index.ts
@@ -1,0 +1,1 @@
+export * from './expandablemessages.component';

--- a/src/app/shared/index.ts
+++ b/src/app/shared/index.ts
@@ -4,6 +4,7 @@
 export * from './header/index';
 export * from './navbar/index';
 export * from './breadcrumbs/index';
+export * from './expandablemessages/index';
 export * from './featuremap/index';
 export * from './fileuploader/index';
 export * from './services/index';

--- a/src/app/shared/services/api/api.service.ts
+++ b/src/app/shared/services/api/api.service.ts
@@ -40,8 +40,7 @@ export class APIService {
      * @constructor
      */
     constructor(private http: Http) {
-        this.baseUrl = environment.server;
-        this.baseUrl = !this.baseUrl.endsWith('/') ? this.baseUrl += '/' : this.baseUrl;
+        this.baseUrl = environment.server + environment.apiExtension;
     }
 
     public getAuthToken(username: string, password: string): Observable<string> {

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -11,6 +11,7 @@ import { APIService } from './services/api/index';
 import { ButtonModule, MenubarModule, BreadcrumbModule, MessagesModule, ProgressBarModule } from 'primeng/primeng';
 import { SharedModule as PrimeSharedModule } from 'primeng/primeng';
 import { FileuploaderComponent } from './fileuploader/fileuploader.component';
+import { ExpandableMessagesComponent } from './expandablemessages/expandablemessages.component';
 
 /**
  * Do not specify providers for modules that might be imported by a lazy loaded module.
@@ -20,9 +21,9 @@ import { FileuploaderComponent } from './fileuploader/fileuploader.component';
   imports: [CommonModule, RouterModule, MenubarModule, BreadcrumbModule, ButtonModule, MessagesModule,
       ProgressBarModule, PrimeSharedModule],
   declarations: [HeaderComponent, NavbarComponent, BreadcrumbsComponent, FeatureMapComponent, FileuploaderComponent,
-      MarkerDirective, TruncatePipe],
+      MarkerDirective, TruncatePipe, ExpandableMessagesComponent],
   exports: [CommonModule, FormsModule, RouterModule, HeaderComponent, NavbarComponent, BreadcrumbsComponent,
-      FeatureMapComponent, FileuploaderComponent, MarkerDirective, TruncatePipe]
+      ExpandableMessagesComponent, FeatureMapComponent, FileuploaderComponent, MarkerDirective, TruncatePipe]
 })
 export class SharedModule {
   static forRoot(): ModuleWithProviders {

--- a/src/app/shared/utils/consts.ts
+++ b/src/app/shared/utils/consts.ts
@@ -3,3 +3,5 @@ export let DATASET_TYPE_MAP: any = {
     observation: 'Observation',
     species_observation: 'Species Observation'
 };
+
+export let DEFAULT_GROWL_LIFE: number = 7000;

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,5 @@
 export const environment = {
     production: true,
-    server: 'https://biosys.dpaw.wa.gov.au/api'
+    server: 'https://biosys.dpaw.wa.gov.au',
+    apiExtension: '/api/'
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -5,5 +5,6 @@
 
 export const environment = {
     production: false,
-    server: 'http://localhost:8000/api'
+    server: 'http://localhost:8000',
+    apiExtension: '/api/'
 };

--- a/src/environments/environment.uat.ts
+++ b/src/environments/environment.uat.ts
@@ -1,4 +1,5 @@
 export const environment = {
     production: true,
-    server: 'https://biosys-uat.dpaw.wa.gov.au/api'
+    server: 'https://biosys-uat.dpaw.wa.gov.au',
+    apiExtension: '/api/'
 };


### PR DESCRIPTION
Added expandable messages component that allow error / warning messages to be truncated and expanded. Using this component for records upload.

Added a default growl life of 7s for all growls (up from 3).

Use a timeout for growls that don't disappear (this occurs for growls that are populated on init) to force them to disappear.

In manage data page, records list will be updated even if an errors are returned.