### PR TITLE
Put long before lat in mouse position control on map.

### DIFF
--- a/src/app/pages/data/manage-data/manage-data.component.ts
+++ b/src/app/pages/data/manage-data/manage-data.component.ts
@@ -153,7 +153,7 @@ export class ManageDataComponent implements OnInit, OnDestroy {
 
         L.control.layers(null, getOverlayLayers()).addTo(this.map);
 
-        L.control.mousePosition({emptyString: ''}).addTo(this.map);
+        L.control.mousePosition({emptyString: '', lngFirst: true, separator: ', '}).addTo(this.map);
 
         L.latlngGraticule().addTo(this.map);
 

--- a/src/app/pages/home/home.component.ts
+++ b/src/app/pages/home/home.component.ts
@@ -56,7 +56,7 @@ export class HomeComponent implements OnInit {
 
         L.control.layers(null, getOverlayLayers()).addTo(this.map);
 
-        L.control.mousePosition({emptyString: ''}).addTo(this.map);
+        L.control.mousePosition({emptyString: '', lngFirst: true, separator: ', '}).addTo(this.map);
 
         L.latlngGraticule().addTo(this.map);
 

--- a/src/app/shared/featuremap/featuremap.component.ts
+++ b/src/app/shared/featuremap/featuremap.component.ts
@@ -95,7 +95,7 @@ export class FeatureMapComponent implements OnInit, OnChanges {
 
         L.control.layers(null, getOverlayLayers()).addTo(this.map);
 
-        L.control.mousePosition({emptyString: ''}).addTo(this.map);
+        L.control.mousePosition({emptyString: '', lngFirst: true, separator: ', '}).addTo(this.map);
 
         L.latlngGraticule().addTo(this.map);
 


### PR DESCRIPTION
Changed ': ' to ', ' for mouse position separator.