### PR TITLE
6712: Stop spinners when creating a project

### DIFF
--- a/src/app/pages/management/edit-project/edit-project.component.ts
+++ b/src/app/pages/management/edit-project/edit-project.component.ts
@@ -221,6 +221,9 @@ export class EditProjectComponent implements OnInit {
                     this.breadcrumbItems.push({label: 'Edit ' + this.project.name});
                     this.projectErrors = {};
                     this.isEditing = false;
+                    // The next two lines are for stopping the spinner on datasets and sites tables
+                    this.datasets = [];
+                    this.flatSites = [];
                 },
                 (errors: APIError) => this.projectErrors = errors.text
             );


### PR DESCRIPTION
Forced datasets and sites var creation (empty) after creating a project to stop spinners.