### PR TITLE
View record, date filter. Set the end date time to 23h59m59s 

### DIFF
--- a/src/app/pages/data-view-export/view-records/view-records.component.ts
+++ b/src/app/pages/data-view-export/view-records/view-records.component.ts
@@ -113,6 +113,8 @@ export class ViewRecordsComponent implements OnInit {
         }
 
         if (this.dateEnd) {
+            // set time to 23h59m59s to include the whole day in search
+            this.dateEnd.setHours(23, 59, 59);
             datasetParams['record__datetime__lte'] = this.recordParams['datetime__lte'] =
                 this.dateEnd.toISOString();
         }


### PR DESCRIPTION
to include the whole day in the search. Without that the search on a single day didn't work.