### PR TITLE
When on Windows the file uploader wasn't detecting the file type.

### DIFF
--- a/src/app/pages/data-management/manage-data/manage-data.component.ts
+++ b/src/app/pages/data-management/manage-data/manage-data.component.ts
@@ -284,7 +284,7 @@ export class ManageDataComponent implements OnInit, OnDestroy {
         // use the file list of uploader instead of the file list given in the event so we can add/remove to it.
         const files: File[] = this.uploader.files;
         let file: File = files.pop();
-        // strangely on Windows the Blob.type (or file.blob here) is empty
+        // strangely on Windows the Blob.type (or file.type here) is empty
         // infer the mime type from the file extension
         if (!file.type) {
             const fileName = file.name;


### PR DESCRIPTION
Workaround the issue of Blob.type not being populated on Windows (independent of the browser). Still dodgy on IE11 (file name missing) but at least the user can upload a file.