### PR TITLE
New admin only workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@
 
 ## Installation
 
-The Biosys Client is build on Angular. To use the commands below, you need to globally install Angular-CLI:
-
+The Biosys Client is build on Angular. To use the commands below, you need to globally install Angular-CLI v6.
+Note: the use installation of the angular CLI is not mandatory. All the ng CLI command can be done through npm commands.
+Optional
 ```bash
-npm install -g @angular/cli
+npm install -g @angular/cli@6.1.4
 ```
 
 This project contains submodules. To clone both the project and submodules, use:
@@ -36,7 +37,7 @@ npm install
 To run a development server, use: 
 
 ```bash
-ng serve
+npm start
 ``` 
 
 Navigate to [http://localhost:4200/](http://localhost:4200/). The app will automatically reload if you change any of the source files.
@@ -48,17 +49,17 @@ Navigate to [http://localhost:4200/](http://localhost:4200/). The app will autom
 To build the project for UAT, use: 
 
 ```bash
-ng build --configuration=dbca-uat --prod
+npm run build -- --configuration=dbca-uat --prod
  ```
 
 The build artifacts will be stored in the `dist/` directory, which are then to be copied to your UAT server.
 
 ### Build for production
 
-To build the project for production, use: 
+To build the project for production (DBCA for example), use: 
 
 ```bash
-ng build --configuration=dbca-prod --prod
+npm run build -- --configuration=dbca-prod --prod
  ```
 
 The build artifacts will be stored in the `dist/` directory, which are then to be copied to your production server.
@@ -68,7 +69,7 @@ The build artifacts will be stored in the `dist/` directory, which are then to b
 To execute the unit tests via [Karma](https://karma-runner.github.io), use:
 
 ```bash
-ng test
+npm run test
 ```
 
 ## Running end-to-end tests
@@ -76,28 +77,32 @@ ng test
 To execute the end-to-end tests via [Protractor](http://www.protractortest.org/), use:
 
 ```bash
-ng e2e
+npm run e2e
 ```
 
 Before running the tests make sure you are serving the app via:
  
 ```bash 
-ng serve
+npm start
 ```
+
+Any other ng command can be issued through npm with:
+```
+npm run ng -- [ng-params]
 
 ## Further help
 
-To get more help on the Angular CLI use:
+Ex: to get more help on the Angular CLI use:
 
 ```bash
-ng help
+npm run ng -- help
 ```
 
 Alternatively read the [Angular CLI README](https://github.com/angular/angular-cli/blob/master/README.md).
 
 
 ## Deployments
-####  Staging (EC2 instance: https://staging.gaiaresources.com.au))
+####  Gaia Staging (EC2 instance: https://staging.gaiaresources.com.au))
 assumes you have a ssh config name staging-biosys
 ```bash
 npm run build -- --configuration=staging --prod

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -31,10 +31,12 @@ import { AuthGuard } from './shared/guards/auth.guard';
 import { AdminGuard } from './shared/guards/admin.guard';
 import { DataEngineerGuard } from './shared/guards/data-engineer.guard';
 import { TeamMemberGuard } from './shared/guards/team-member.guard';
+import { AdminOnlyComponent } from './pages/accounts/admin-only/admin-only.component';
 
 @NgModule({
     declarations: [
-        AppComponent
+        AppComponent,
+        AdminOnlyComponent
     ],
     imports: [
         BrowserModule,

--- a/src/app/pages/accounts/accounts.routes.ts
+++ b/src/app/pages/accounts/accounts.routes.ts
@@ -3,6 +3,7 @@ import { LoginComponent } from './login/login.component';
 import { ResetPasswordComponent } from './reset-password/reset-password.component';
 import { ForgotPasswordComponent } from './forgot-password/forgot-password.component';
 import { ChangePasswordComponent } from './change-password/change-password.component';
+import { AdminOnlyComponent } from './admin-only/admin-only.component';
 
 export const AccountsRoutes: Route[] = [
     {
@@ -20,5 +21,9 @@ export const AccountsRoutes: Route[] = [
     {
         path: 'reset-password/:uid/:token',
         component: ResetPasswordComponent
+    },
+    {
+        path: 'admin-only',
+        component: AdminOnlyComponent
     }
 ];

--- a/src/app/pages/accounts/admin-only/admin-only.component.html
+++ b/src/app/pages/accounts/admin-only/admin-only.component.html
@@ -2,8 +2,8 @@
     <biosys-header></biosys-header>
     <div class="row mt-3">
         <div class="col">
-            <h4>Sorry this application is currently authorised for general access</h4>
-            <p>If you wish to access it please contact the BioSys administrator.</p>
+            <h4>Sorry this application is currently not authorised for general access.</h4>
+            <p>Please come back later or if you wish to access it now, please contact the BioSys administrator.</p>
         </div>
     </div>
 </div>

--- a/src/app/pages/accounts/admin-only/admin-only.component.html
+++ b/src/app/pages/accounts/admin-only/admin-only.component.html
@@ -1,0 +1,9 @@
+<div class="container">
+    <biosys-header></biosys-header>
+    <div class="row mt-3">
+        <div class="col">
+            <h4>Sorry this application is currently authorised for general access</h4>
+            <p>If you wish to access it please contact the BioSys administrator.</p>
+        </div>
+    </div>
+</div>

--- a/src/app/pages/accounts/admin-only/admin-only.component.spec.ts
+++ b/src/app/pages/accounts/admin-only/admin-only.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AdminOnlyComponent } from './admin-only.component';
+
+describe('AdminOnlyComponent', () => {
+  let component: AdminOnlyComponent;
+  let fixture: ComponentFixture<AdminOnlyComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ AdminOnlyComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(AdminOnlyComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/pages/accounts/admin-only/admin-only.component.ts
+++ b/src/app/pages/accounts/admin-only/admin-only.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'biosys-admin-only',
+  templateUrl: './admin-only.component.html',
+  styleUrls: ['./admin-only.component.css']
+})
+export class AdminOnlyComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/app/pages/accounts/login/login.component.ts
+++ b/src/app/pages/accounts/login/login.component.ts
@@ -2,6 +2,8 @@ import { Component } from '@angular/core';
 import { Router } from '@angular/router';
 import { FormGroup, FormBuilder, Validators } from '@angular/forms';
 import { AuthService } from '../../../../biosys-core/services/auth.service';
+import { User } from '../../../../biosys-core/interfaces/api.interfaces';
+import { environment } from '../../../../environments/environment';
 
 @Component({
     moduleId: module.id,
@@ -26,7 +28,17 @@ export class LoginComponent {
         event.preventDefault();
 
         this.authService.login(this.loginForm.value.username, this.loginForm.value.password).subscribe(
-            () => this.router.navigate(['/']),
+            (user: User) => {
+                // 25/06/2019: a little hack to prevent public users registered through a mobile app like koala or slug to access the app.
+                // this is a temp solution waiting for the update of the server's permission model.
+                const isAppAdminOnly = environment.hasOwnProperty('adminOnly') && environment['adminOnly'];
+                const forbidden = isAppAdminOnly && !(user.is_admin  || user.is_data_engineer);
+                if (forbidden) {
+                    this.router.navigate(['/admin-only']);
+                } else {
+                    this.router.navigate(['/']);
+                }
+            },
             () => this.errorMessages = ['Invalid username/password.']
         );
 

--- a/src/environments/environment.mksas-prod.ts
+++ b/src/environments/environment.mksas-prod.ts
@@ -2,4 +2,5 @@ export const environment = {
     production: false,
     server: 'https://mksas-api.gaiaresources.com.au',
     apiExtension: '/api/',
+    adminOnly: true,
 };

--- a/src/environments/environment.oeh-prod.ts
+++ b/src/environments/environment.oeh-prod.ts
@@ -2,4 +2,5 @@ export const environment = {
     production: false,
     server: 'https://koalawatch-api.gaiaresources.com.au',
     apiExtension: '/api/',
+    adminOnly: true,
 };


### PR DESCRIPTION
To prevent public users registered from app to access the app we can now build the app to be admin only.
In this case after login the non admin/data-engineer will be redirected to a message page.

Also updated the README