### PR TITLE
BIOSYS-44 added conditional to ensure only invalidation column editable

### DIFF
--- a/src/app/shared/edit-records-table/edit-records-table.component.html
+++ b/src/app/shared/edit-records-table/edit-records-table.component.html
@@ -77,7 +77,7 @@
             <!-- have editable cells if record not locked -->
             <ng-container
                     *ngFor="let field of !rowData._locked ? dataset?.data_package?.resources[0]?.schema?.fields : []">
-                <td *ngIf="!(field | isHiddenField)" [pEditableColumn]="rowData" [pEditableColumnField]="field.name">
+                <td *ngIf="!(field | isHiddenField)" [pEditableColumn]="rowData" [pEditableColumnField]="field.name" [pEditableColumnDisabled]=checkColumnEditable(field.name)>
                     <p-cellEditor>
                         <ng-template pTemplate="input">
                             <span [ngSwitch]="getFieldType(field)">

--- a/src/app/shared/edit-records-table/edit-records-table.component.ts
+++ b/src/app/shared/edit-records-table/edit-records-table.component.ts
@@ -99,6 +99,10 @@ export class EditRecordsTableComponent {
         return this._dataset;
     }
 
+    public checkColumnEditable(fieldName: string) {
+        return (fieldName === 'Reason for Invalidation') ? false : true;
+    }
+
     public reloadRecords() {
         // reload table page without resetting pagination/ordering/search params unlike reset()
         this.recordsDatatable.onLazyLoad.emit(this.recordsDatatable.createLazyLoadMetadata());


### PR DESCRIPTION
From Data Management => Project => Records table

Upon unlocking a record, all fields would become editable. This has been locked down to only the data column "Reason for Invalidation"